### PR TITLE
Fix typo in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl
 
 ## Features
 
-- [X] Compiles docker images into portable binaries
+- [X] Compile docker images into portable binaries
 - [X] Rootless containers
 - [ ] MacOS and Windows support (using QEMU)
 - [X] x86_64 support

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl
 
 ## Features
 
-- [X] Compiler docker images into portable binaries
+- [X] Compiles docker images into portable binaries
 - [X] Rootless containers
 - [ ] MacOS and Windows support (using QEMU)
 - [X] x86_64 support


### PR DESCRIPTION
Great Project!

### Summary

This PR corrects a typo in the README file. The section under "Features" previously stated "Compiler docker images into portable binaries," which has now been corrected to "Compiles docker images into portable binaries."

### Changes

- Updated the typo in the "Features" section of the README file from "Compiler" to "Compiles."

### Before

```md
- [X] Compiler docker images into portable binaries
```

### After

```md
- [X] Compile docker images into portable binaries
```

### Testing

- No code changes were made; only the README file was updated.
- Ensure the README displays correctly after the change.

---

### Checklist

- [x] Corrected the typo in the README file
- [x] Verified the README file renders correctly

Please review and merge this change. Thank you!